### PR TITLE
Transformado o email em um link de email

### DIFF
--- a/src/pages/Contatos/index.jsx
+++ b/src/pages/Contatos/index.jsx
@@ -7,7 +7,7 @@ export const Contatos = () => {
                 <div className='contatos'>
                     <p className='contatosName'>Contatos</p>
                     <p className='contatosTelEmail'>Telefone: (61) 98516-8437</p>
-                    <p className='contatosTelEmail'>Email: soraiaduartte@gmail.com</p>
+                    <p className='contatosTelEmail'>Email: <a href="mailto:soraiaduartte@gmail.com">soraiaduartte@gmail.com</a></p>
                     <div className='lineContatos'></div>
                 </div>
             </div>


### PR DESCRIPTION
> A pull request tem como intenção contribuir para a aplicação, ressaltando o respeito pelo esforço empregado.
De forma alguma se tem a intenção de apontar uma forma melhor, apenas, uma forma diferente de fazer algo.

### Transformado o e-mail em um link de e-mail

Após a alteração, o endereço de e-mail na seção de contatos é exibido como um link de e-mail. 
Dessa forma, é possível que o usuário clique no link para abrir seu cliente de e-mail padrão com o endereço de e-mail pré-preenchido.
A modificação tem o objetivo de facilitar o possível contato que os usuários possam fazer, sem que tenham que copiar, manualmente, o endereço do e-mail.

- Adicionado link de e-mail usando a tag <a> com o atributo href definido como 'mailto:' seguido do endereço de e-mail.
- Atualizado o componente Contatos no arquivo index.js.

![depois](https://github.com/jessicaduarte95/designInterioresProjeto/assets/122949777/218e5506-4e4d-4736-974b-5088456ca83a)

📮 Contato:
E-mail: [guilhermesantos.adv@protonmail.com](mailto:guilhermesantos.adv@protonmail.com)
Twitter: https://twitter.com/Guilher_me99

